### PR TITLE
Add RequestMethod configuration option

### DIFF
--- a/DependencyInjection/BeelabRecaptcha2Extension.php
+++ b/DependencyInjection/BeelabRecaptcha2Extension.php
@@ -23,7 +23,21 @@ class BeelabRecaptcha2Extension extends Extension
         $container->setParameter('beelab_recaptcha2.secret', $config['secret']);
         $container->setParameter('beelab_recaptcha2.enabled', $config['enabled']);
 
+        $requestMethodClass = $this->getRequestMethod($config['request_method']);
+        $container->setParameter('beelab_recaptcha2.request_method', $requestMethodClass);
+
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+    }
+
+    private function getRequestMethod($requestMethod)
+    {
+        switch ($requestMethod) {
+            case 'curl_post':
+                return 'ReCaptcha\RequestMethod\CurlPost';
+            case 'post':
+            default:
+                return 'ReCaptcha\RequestMethod\Post';
+        }
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -20,7 +20,7 @@ class Configuration implements ConfigurationInterface
         $rootNode
             ->children()
                 ->enumNode('request_method')
-                    ->values(['curl_post', 'post'])
+                    ->values(array('curl_post', 'post'))
                     ->defaultValue('post')
                 ->end()
                 ->scalarNode('site_key')

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -19,6 +19,10 @@ class Configuration implements ConfigurationInterface
         $rootNode = $treeBuilder->root('beelab_recaptcha2');
         $rootNode
             ->children()
+                ->enumNode('request_method')
+                    ->values(['curl_post', 'post'])
+                    ->defaultValue('post')
+                ->end()
                 ->scalarNode('site_key')
                     ->isRequired()
                 ->end()

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -5,8 +5,10 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
+        <service id="beelab_recaptcha2.google_recaptcha.request_method" class="%beelab_recaptcha2.request_method%" />
         <service id="beelab_recaptcha2.google_recaptcha" class="ReCaptcha\ReCaptcha">
             <argument>%beelab_recaptcha2.secret%</argument>
+            <argument type="service" id="beelab_recaptcha2.google_recaptcha.request_method" />
         </service>
         <service id="beelab_recaptcha2.type" class="Beelab\Recaptcha2Bundle\Form\Type\RecaptchaType">
             <argument>%beelab_recaptcha2.site_key%</argument>

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -54,6 +54,19 @@ beelab_recaptcha2:
     enabled: false
 ```
 
+If your PHP environment has restrictions about `file_get_contents()` making HTTP requests you can use another `RequestMethod` from Google's Recaptcha library.
+
+Currently this Bundle supports the default `Post` and `CurlPost` methods. You can use the later by adding in your `config.yml`:
+
+``` yaml
+# app/config/config.yml
+
+beelab_recaptcha2:
+    request_method: curl_post
+```
+
+Otherwise the default value `post` will be used.
+
 ### 3. Usage
 
 In your form, use `beelab_recaptcha2` form type, as any other Symfony form types.

--- a/Tests/DependencyInjection/BeelabRecaptcha2ExtensionTest.php
+++ b/Tests/DependencyInjection/BeelabRecaptcha2ExtensionTest.php
@@ -21,6 +21,7 @@ class BeelabRecaptcha2ExtensionTest extends \PHPUnit_Framework_TestCase
 
         $extension = new BeelabRecaptcha2Extension();
         $configs = array(
+            array('request_method' => 'curl_post'),
             array('site_key' => 'foo'),
             array('secret' => 'bar'),
             array('enabled' => true),


### PR DESCRIPTION
Based on the problem I had on issue #10 I took the liberty of hacking a way to solve my problem. Please feel free to suggest any changes or to point whatever I did wrong.

Essentially I created a service named `beelab_recaptcha2.google_recaptcha.request_method` to represent Google's `RequestMethod` instance in order to inject it in the `beelab_recaptcha2.google_recaptcha` service.

The class for `beelab_recaptcha2.google_recaptcha.request_method` is picked when the configuration is loaded in `BeelabRecaptcha2Extension` by setting the `beelab_recaptcha2.request_method` parameter.

It defaults to how it was before (`Post`).