### PR TITLE
Fix RecaptchaType that isn't a compound form but a field

### DIFF
--- a/Form/Type/RecaptchaType.php
+++ b/Form/Type/RecaptchaType.php
@@ -33,10 +33,10 @@ class RecaptchaType extends AbstractType
     {
         // BC for Symfony < 3
         if (!method_exists('Symfony\Component\Form\AbstractType', 'getBlockPrefix')) {
-            return 'form';
+            return 'text';
         }
 
-        return 'Symfony\Component\Form\Extension\Core\Type\FormType';
+        return 'Symfony\Component\Form\Extension\Core\Type\TextType';
     }
 
     /**

--- a/Tests/Form/Type/RecaptchaTypeTest.php
+++ b/Tests/Form/Type/RecaptchaTypeTest.php
@@ -17,7 +17,7 @@ class RecaptchaTypeTest extends \PHPUnit_Framework_TestCase
     public function testGetParent()
     {
         $type = new RecaptchaType('foo');
-        $this->assertTrue('form' === $type->getParent() || 'Symfony\Component\Form\Extension\Core\Type\FormType' === $type->getParent());
+        $this->assertTrue('text' === $type->getParent() || 'Symfony\Component\Form\Extension\Core\Type\TextType' === $type->getParent());
     }
 
     public function testGetName()


### PR DESCRIPTION
## Subject

The `captcha` field is actually handle like a form, but he must be IMO handled like a field.

I actually got a `TransformationFailedException` during the validation of the following form, because `RecaptchaType` expect an array, but if i submit an array, i've `This form should not contain extra fields.`.

## Step to reproduce
### Form
```php
class PreRegisterType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('email', EmailType::class)
            ->add('captcha', RecaptchaType::class, [
                'mapped' => false,
                'constraints' => new Recaptcha2(),
            ])
        ;
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefaults([
            'data_class' => User::class,
        ]);
    }
}
```
### POST Request
```json
{"email":"zefzef@fefze.fr", "captcha": "03AHJ_Vuu0yGdYrMErDmv8uzFTkvH2brefcSpwwgLK90O3Q7Te3sJZuMOHbyD_jxgEN2mycZrr85fuGPwu-KPAmgP2ewjfdNQnzKrq3TAX4g7_ouOAksZGObhGqYmV9ugHQrGmxgsKMiZv9aGCec4e_o3hjCkxOn1FMRdr0xL7K6_XWpitdBkJ_PNVs_WKo3MLTemO_jhuaBxLLkeDIBw9RBPM9R5t0MFR5cJtEb1QO-m99qxIuyofkeM-2EBDYePITdqkMNfXLDZbjsIEN8e1U0b06OWz0MRoPzKRVFGNEtpBClKvESPndwEqlitpgjzdsP1YHdKVyY4lXCs7iBkskCdZeB0b4usIXlu2bo83hWU2Rvq3bmJvFEhCKhpP9t1Q14x_9YlI4WuaryB_6Ky-M7r_KoTGuizYvFR-chm0KtsgBemO6_Kd-BPDFAsSJY1z7Sd6O6bsNDpj3zF9NqVfRd5IXzAozvSvV0_9O86P02iKeRSWR1yVvj_0ngSHXftUizrgCjPQ-b6aWEvz3F_4-8wXhQ_FeYsJFAr4E44Ws-JmWoerZYv8fWXNQs_6bqezxmhzM-NSQhSLCYurHiuN1tbbH9FznNJaBvRqeZ0Pji08XIZTygCA_zOFhSmW5_huaxu8db48Asj05v6tuj88axKNUn-gQd08wlA4NgQ5A2xC0hcO2Mj9Ebbn59iOf-uhRusGUr7um3xMHKRlLHYKPq2AyKWisJGyMurF0z5kVk9K80chAFu7jDzniTLG7KDLq3QfT4eTZD3ltesw1tZr7gSbQ6Oat4jkLPsG6oo6G-teZD6KOK-VrJWvamAGExQrPLc4nTZkfLUkTdWwSNaSwcV2FaZ8cfx_PFx-DTRsN-kED_dovm7oGpysykyH_sxl3F2EBNjmOYr6"}
```
### JSON Response
```json
{
    "errors": ["Cette valeur n'est pas valide."],
    "children": {
        "email": {
            "errors": ["email_not_unique"]
        },
        "captcha": {}
    }
}
```
### JSON Response Expected
```json
{
    "children": {
        "email": {
            "errors": ["email_not_unique"]
        },
        "captcha": {
            "errors": ["Invalid ReCaptcha."]
        }
    }
}
```
## Other
 - [X] Update Test
 - [x] Test Passes