### PR TITLE
Update bundle dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,15 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
-        "symfony/framework-bundle": "~2.7|~3.0",
-        "symfony/dependency-injection": "~2.7|~3.0",
-        "symfony/form": "~2.7|~3.0",
-        "symfony/validator": "~2.7|~3.0",
+        "php": ">=5.5.9",
+        "symfony/framework-bundle": "^2.7|^3.0",
+        "symfony/form": "^2.7|^3.0",
+        "symfony/validator": "^2.7|^3.0",
         "google/recaptcha": "^1.1"
     },
     "require-dev": {
-        "symfony/expression-language": "~2.7|~3.0",
-        "symfony/phpunit-bridge": "~2.7|~3.0",
+        "symfony/expression-language": "^2.7|^3.0",
+        "symfony/phpunit-bridge": "^2.7|^3.0",
         "phpunit/phpunit": "^4.8"
     },
     "config": {


### PR DESCRIPTION
## Subject

The PHP version under 5.5.9 patch are vulnerable [CVE-2013-7226](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2013-7226), it's a best practice to drop support on vulnerable version .

The `~` is now deprecated too in favor of `^` for library that stick the semantic versioning closer [Doc](https://getcomposer.org/doc/articles/versions.md#caret)