### PR TITLE
Improve flexibility of the RecaptchaVerifier

### DIFF
--- a/Recaptcha/RecaptchaVerifier.php
+++ b/Recaptcha/RecaptchaVerifier.php
@@ -39,11 +39,14 @@ class RecaptchaVerifier
 
     /**
      * Verify reCaptcha response.
+     *
+     * @param string $recaptchaValue
+     *
+     * @throws RecaptchaException
      */
-    public function verify()
+    public function verify($recaptchaValue)
     {
         if ($this->enabled) {
-            $recaptchaValue = $this->request->request->get('g-recaptcha-response');
             /* @var \ReCaptcha\Response $response */
             $response = $this->reCaptcha->verify($recaptchaValue, $this->request->getClientIp());
             if (!$response->isSuccess()) {

--- a/Tests/Recaptcha/RecaptchaVerifierTest.php
+++ b/Tests/Recaptcha/RecaptchaVerifierTest.php
@@ -22,21 +22,18 @@ class RecaptchaVerifierTest extends \PHPUnit_Framework_TestCase
     public function testVerifyDisabled()
     {
         $verifier = new RecaptchaVerifier($this->recaptcha, $this->stack, false);
-        $verifier->verify();
+        $verifier->verify('captcha-response');
     }
 
     public function testVerifySuccess()
     {
-        $bag = $this->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
-            ->disableOriginalConstructor()->getMock();
-        $bag->expects($this->once())->method('get')->will($this->returnValue('foo'));
-        $this->request->request = $bag;
+        $this->request->expects($this->once())->method('getClientIp')->will($this->returnValue('127.0.0.1'));
         $response = $this->getMockBuilder('ReCaptcha\Response')->disableOriginalConstructor()->getMock();
         $response->expects($this->once())->method('isSuccess')->will($this->returnValue(true));
         $this->recaptcha->expects($this->once())->method('verify')->will($this->returnValue($response));
 
         $verifier = new RecaptchaVerifier($this->recaptcha, $this->stack);
-        $verifier->verify();
+        $verifier->verify('captcha-response');
     }
 
     /**
@@ -44,16 +41,13 @@ class RecaptchaVerifierTest extends \PHPUnit_Framework_TestCase
      */
     public function testVerifyFailure()
     {
-        $bag = $this->getMockBuilder('Symfony\Component\HttpFoundation\ParameterBag')
-            ->disableOriginalConstructor()->getMock();
-        $bag->expects($this->once())->method('get')->will($this->returnValue('foo'));
-        $this->request->request = $bag;
+        $this->request->expects($this->once())->method('getClientIp')->will($this->returnValue('127.0.0.1'));
         $response = $this->getMockBuilder('ReCaptcha\Response')->disableOriginalConstructor()->getMock();
         $response->expects($this->once())->method('isSuccess')->will($this->returnValue(false));
         $response->expects($this->once())->method('getErrorCodes')->will($this->returnValue([]));
         $this->recaptcha->expects($this->once())->method('verify')->will($this->returnValue($response));
 
         $verifier = new RecaptchaVerifier($this->recaptcha, $this->stack);
-        $verifier->verify();
+        $verifier->verify('captcha-response');
     }
 }

--- a/Validator/Constraints/Recaptcha2Validator.php
+++ b/Validator/Constraints/Recaptcha2Validator.php
@@ -31,7 +31,7 @@ class Recaptcha2Validator extends ConstraintValidator
     public function validate($value, Constraint $constraint)
     {
         try {
-            $this->verifier->verify();
+            $this->verifier->verify($value);
         } catch (RecaptchaException $e) {
             $this->context->addViolation($constraint->message);
         }


### PR DESCRIPTION
## Subject

The verifier is hard depending onto a specific parameter in the RequestStack, he must be related to the value of the RecaptchaType

## Step to reproduce

```php
class PreRegisterType extends AbstractType
{
    public function buildForm(FormBuilderInterface $builder, array $options)
    {
        $builder
            ->add('email', EmailType::class)
            ->add('captcha', RecaptchaType::class, [
                'mapped' => false,
                'constraints' => new Recaptcha2(),
            ])
        ;
    }

    public function configureOptions(OptionsResolver $resolver)
    {
        $resolver->setDefaults([
            'data_class' => User::class,
        ]);
    }
}
```

In this case the name of the parameter in the `RequestStack` is `captcha` and not `g-captcha-response`.

## Tests

- [X] Tests updated
- [X] Tests pass