### PR TITLE
Swap current for master request

### DIFF
--- a/Recaptcha/RecaptchaVerifier.php
+++ b/Recaptcha/RecaptchaVerifier.php
@@ -36,7 +36,7 @@ class RecaptchaVerifier
     public function __construct(ReCaptcha $reCaptcha, RequestStack $requestStack, $enabled = true)
     {
         $this->reCaptcha = $reCaptcha;
-        $this->request = $requestStack->getCurrentRequest();
+        $this->request = $requestStack->getMasterRequest();
         $this->enabled = $enabled;
     }
 

--- a/Tests/Recaptcha/RecaptchaVerifierTest.php
+++ b/Tests/Recaptcha/RecaptchaVerifierTest.php
@@ -20,7 +20,7 @@ class RecaptchaVerifierTest extends TestCase
         $this->recaptcha = $this->getMockBuilder(ReCaptcha::class)->disableOriginalConstructor()->getMock();
         $this->request = $this->getMockBuilder(Request::class)->disableOriginalConstructor()->getMock();
         $this->stack = $this->createMock(RequestStack::class);
-        $this->stack->expects($this->once())->method('getCurrentRequest')->will($this->returnValue($this->request));
+        $this->stack->expects($this->once())->method('getMasterRequest')->will($this->returnValue($this->request));
     }
 
     public function testVerifyDisabled()


### PR DESCRIPTION
*Initial issue*  
Our form is created and rendered in a sub request. The bundle is using the current request and is therefore never able to retrieve the captcha data from the POST data.

*Solution*  
Use the master request instead of the current one. This shouldn't cause any backward incompatibility issues as the current and master request are equal when not using sub requests.