### PR TITLE
feat: added invisible type

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -104,9 +104,16 @@ class RegistrationType extends AbstractType
             ->add('name')
             ->add('plainPassword', PasswordType::class)
             ->add('captcha', RecaptchaType::class, [
+                // You can use RecaptchaSubmitType
                 // "groups" option is not mandatory
                 'constraints' => new Recaptcha2(['groups' => ['create']]),
             ])
+            // For Invisible Recaptcha
+            /*
+            ->add('captcha', RecaptchaSubmitType::class, [
+                'label' => 'Save'
+            ])
+            */
         ;
     }
 }
@@ -128,6 +135,19 @@ For example, you can use the following in a Twig template, to get the currently 
 
 ```jinja
 <script src="//www.google.com/recaptcha/api.js?hl={{ app.request.locale }}"></script>
+```
+
+To use invisible ReCaptcha you will need to define an additional callback:
+
+```js
+function recaptchaCallback (token) {
+    var elem = document.querySelector(".g-recaptcha");
+    while ((elem = elem.parentElement) !== null) {
+    if (elem.nodeType === Node.ELEMENT_NODE && elem.tagName === 'FORM') {
+        elem.submit();
+        break;
+    }
+}
 ```
 
 ### 4. Customization

--- a/src/Form/Type/RecaptchaSubmitType.php
+++ b/src/Form/Type/RecaptchaSubmitType.php
@@ -33,8 +33,8 @@ class RecaptchaSubmitType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'label'       => false,
-            'mapped'      => false,
+            'label' => false,
+            'mapped' => false,
             'constraints' => new Recaptcha2(),
         ]);
     }

--- a/src/Form/Type/RecaptchaSubmitType.php
+++ b/src/Form/Type/RecaptchaSubmitType.php
@@ -9,7 +9,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
-class RecaptchaType extends AbstractType
+class RecaptchaSubmitType extends AbstractType
 {
     protected $siteKey;
 
@@ -21,24 +21,26 @@ class RecaptchaType extends AbstractType
     public function buildView(FormView $view, FormInterface $form, array $options): void
     {
         $view->vars['site_key'] = $this->siteKey;
-    }
-
-    public function getParent(): string
-    {
-        return TextType::class;
+        $view->vars['button'] = $options['label'];
+        $view->vars['label'] = false;
     }
 
     public function getBlockPrefix(): string
     {
-        return 'beelab_recaptcha2';
+        return 'beelab_recaptcha2_submit';
     }
 
-    public function configureOptions(OptionsResolver $resolver): void
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'label' => false,
-            'mapped' => false,
+            'label'       => false,
+            'mapped'      => false,
             'constraints' => new Recaptcha2(),
         ]);
+    }
+
+    public function getParent()
+    {
+        return TextType::class;
     }
 }

--- a/templates/form_fields.html.twig
+++ b/templates/form_fields.html.twig
@@ -1,3 +1,9 @@
 {% block beelab_recaptcha2_widget -%}
     <div class="g-recaptcha" data-sitekey="{{ site_key }}"></div>
 {%- endblock %}
+
+{%- block beelab_recaptcha2_submit_widget -%}
+    {%- set label = button %}
+    {%- set attr = attr|merge({"data-sitekey": site_key, "data-callback": 'recaptchaCallback', class: (attr.class|default('') ~ ' g-recaptcha')}) -%}
+    {% block submit_widget %}{% endblock %}
+{%- endblock beelab_recaptcha2_submit_widget -%}

--- a/tests/Form/Type/RecaptchaSubmitTypeTest.php
+++ b/tests/Form/Type/RecaptchaSubmitTypeTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Beelab\Recaptcha2Bundle\Tests\Form\Type;
+
+use Beelab\Recaptcha2Bundle\Form\Type\RecaptchaSubmitType;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\FormView;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+final class RecaptchaSubmitTypeTest extends TestCase
+{
+    public function testBuildView(): void
+    {
+        $form = $this->createMock('Symfony\Component\Form\FormInterface');
+        $view = $this->getMockBuilder(FormView::class)->disableOriginalConstructor()->getMock();
+        $type = new RecaptchaSubmitType('foo');
+        $type->buildView($view, $form, ['label' => false]);
+        $this->assertInstanceOf(RecaptchaSubmitType::class, $type);
+    }
+
+    public function testGetParent(): void
+    {
+        $type = new RecaptchaSubmitType('foo');
+        $this->assertEquals(TextType::class, $type->getParent());
+    }
+
+    public function testGetBlockPrefix(): void
+    {
+        $type = new RecaptchaSubmitType('foo');
+        $this->assertEquals('beelab_recaptcha2_submit', $type->getBlockPrefix());
+    }
+
+    public function testConfigureOptions(): void
+    {
+        $resolver = $this->createMock(OptionsResolver::class);
+        $resolver->expects($this->once())->method('setDefaults');
+        $type = new RecaptchaSubmitType('foo');
+        $type->configureOptions($resolver);
+    }
+}


### PR DESCRIPTION
- Add a new type to handle invisible recaptcha v2 (Fix #23).
- Constraint is added to the type by default (why you wouldn't want that ?)