### PR TITLE
Fix: non-scalar value submitted as recaptcha value

### DIFF
--- a/src/Recaptcha/RecaptchaVerifier.php
+++ b/src/Recaptcha/RecaptchaVerifier.php
@@ -4,6 +4,7 @@ namespace Beelab\Recaptcha2Bundle\Recaptcha;
 
 use ReCaptcha\ReCaptcha;
 use ReCaptcha\Response;
+use Symfony\Component\HttpFoundation\Exception\BadRequestException;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -30,7 +31,11 @@ class RecaptchaVerifier
         // If empty, we use the default input drawn by google JS we need to get
         // the value with hardcoded variable
         if (empty($recaptchaValue) && $request->request->has(self::GOOGLE_DEFAULT_INPUT)) {
-            $recaptchaValue = $request->request->get(self::GOOGLE_DEFAULT_INPUT);
+            try {
+                $recaptchaValue = $request->request->get(self::GOOGLE_DEFAULT_INPUT);
+            } catch (BadRequestException) {
+                throw new RecaptchaException(new Response(false));
+            }
         }
 
         if (!is_string($recaptchaValue)) {

--- a/tests/Recaptcha/RecaptchaVerifierTest.php
+++ b/tests/Recaptcha/RecaptchaVerifierTest.php
@@ -73,4 +73,22 @@ final class RecaptchaVerifierTest extends TestCase
         $verifier = new RecaptchaVerifier($this->recaptcha, $this->stack);
         $verifier->verify('captcha-response');
     }
+
+    public function testVerifyRecaptchaValueSubmitted(): void
+    {
+        $this->expectException(RecaptchaException::class);
+
+        $request = new Request();
+        $request->request->set('g-recaptcha-response', []);
+
+        if (\is_callable([$this->stack, 'getMainRequest'])) {
+            $this->stack->expects(self::once())->method('getMainRequest')->willReturn($request);
+        } else {
+            $this->stack->expects(self::once())->method('getMasterRequest')->willReturn($request);
+        }
+        $this->request->expects(self::never())->method('getClientIp');
+
+        $verifier = new RecaptchaVerifier($this->recaptcha, $this->stack);
+        $verifier->verify();
+    }
 }


### PR DESCRIPTION
Fixes `Uncaught PHP Exception Symfony\Component\HttpKernel\Exception\BadRequestHttpException: "Input value "g-recaptcha-response" contains a non-scalar value." at vendor/symfony/http-foundation/InputBag.php:37`