### PR TITLE
Add error code to Recaptcha cosntraint

### DIFF
--- a/src/Validator/Constraints/Recaptcha2.php
+++ b/src/Validator/Constraints/Recaptcha2.php
@@ -9,6 +9,12 @@ use Symfony\Component\Validator\Constraint;
  */
 final class Recaptcha2 extends Constraint
 {
+    public const INVALID_RECAPTCHA_ERROR = 'b2c483cd-90b6-4810-aa45-fd615e89f046';
+
+    protected const ERROR_NAMES = [
+        self::INVALID_RECAPTCHA_ERROR => 'INVALID_RECAPTCHA_ERROR',
+    ];
+
     public string $message = 'Invalid ReCaptcha.';
 
     public function validatedBy(): string

--- a/src/Validator/Constraints/Recaptcha2Validator.php
+++ b/src/Validator/Constraints/Recaptcha2Validator.php
@@ -22,7 +22,10 @@ final class Recaptcha2Validator extends ConstraintValidator
         try {
             $this->verifier->verify($value);
         } catch (RecaptchaException) {
-            $this->context->addViolation($constraint->message);
+            $this->context
+                ->buildViolation($constraint->message)
+                ->setCode(Recaptcha2::INVALID_RECAPTCHA_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/tests/Validator/Constraints/Recaptcha2ValidatorTest.php
+++ b/tests/Validator/Constraints/Recaptcha2ValidatorTest.php
@@ -36,7 +36,7 @@ final class Recaptcha2ValidatorTest extends TestCase
         $exception = new RecaptchaException($response);
         $constraint = new Recaptcha2();
         $this->verifier->expects(self::once())->method('verify')->will(self::throwException($exception));
-        $this->context->expects(self::once())->method('addViolation');
+        $this->context->expects(self::once())->method('buildViolation');
 
         $this->validator->validate('dummy', $constraint);
     }
@@ -45,7 +45,7 @@ final class Recaptcha2ValidatorTest extends TestCase
     {
         $constraint = new Recaptcha2();
         $this->verifier->expects(self::once())->method('verify');
-        $this->context->expects(self::never())->method('addViolation');
+        $this->context->expects(self::never())->method('buildViolation');
 
         $this->validator->validate('dummy', $constraint);
     }
@@ -54,7 +54,7 @@ final class Recaptcha2ValidatorTest extends TestCase
     {
         $constraint = new Recaptcha2();
         $this->verifier->expects(self::once())->method('verify');
-        $this->context->expects(self::never())->method('addViolation');
+        $this->context->expects(self::never())->method('buildViolation');
 
         $this->validator->validate(null, $constraint);
     }


### PR DESCRIPTION
We have form logic that removes all other form errors in case none or an invalid recaptcha is submitted. Having an error code on the constraint help detecting such an error instead of having to check the message.

For reference, similar functionality was added to the [UserPassword](https://github.com/symfony/symfony/pull/50069) constraint in Symfony.