### PR TITLE
PHPUnit: fix warning about deprecated usage of at() matcher

### DIFF
--- a/tests/DependencyInjection/Compiler/TwigFormPassTest.php
+++ b/tests/DependencyInjection/Compiler/TwigFormPassTest.php
@@ -26,8 +26,7 @@ final class TwigFormPassTest extends TestCase
         $builder = $this->createMock(ContainerBuilder::class);
         $definition = $this->createMock(Definition::class);
 
-        $builder->expects($this->at(0))->method('hasDefinition')->willReturn(false);
-        $builder->expects($this->at(1))->method('hasDefinition')->willReturn(true);
+        $builder->expects($this->exactly(2))->method('hasDefinition')->willReturn(false, true);
         $builder->expects($this->once())->method('getDefinition')->willReturn($definition);
         $builder->expects($this->once())->method('hasParameter')->willReturn(false);
         $definition->method('addMethodCall');


### PR DESCRIPTION
```
1) Beelab\Recaptcha2Bundle\Tests\DependencyInjection\Compiler\TwigFormPassTest::testProcessWithoutFilesystemAndWithNativeFilesystem
The at() matcher has been deprecated. It will be removed in PHPUnit 10. Please refactor your test to not rely on the order in which methods are invoked.
```