### PR TITLE
🐛 fix container configuration

### DIFF
--- a/config/services.xml
+++ b/config/services.xml
@@ -5,10 +5,9 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <services>
-        <service id="beelab_recaptcha2.google_recaptcha.request_method" class="%beelab_recaptcha2.request_method%" />
         <service id="beelab_recaptcha2.google_recaptcha" class="ReCaptcha\ReCaptcha">
             <argument>%beelab_recaptcha2.secret%</argument>
-            <argument type="service" id="beelab_recaptcha2.google_recaptcha.request_method" />
+            <argument /><!-- replaced by Configuration -->
         </service>
         <service id="Beelab\Recaptcha2Bundle\Recaptcha\SymfonyClientRequestMethod" public="false">
             <call method="setClient">

--- a/src/BeelabRecaptcha2Bundle.php
+++ b/src/BeelabRecaptcha2Bundle.php
@@ -2,6 +2,7 @@
 
 namespace Beelab\Recaptcha2Bundle;
 
+use Beelab\Recaptcha2Bundle\DependencyInjection\Compiler\RequestMethodPass;
 use Beelab\Recaptcha2Bundle\DependencyInjection\Compiler\TwigFormPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -12,6 +13,7 @@ final class BeelabRecaptcha2Bundle extends Bundle
     {
         parent::build($container);
         $container->addCompilerPass(new TwigFormPass());
+        $container->addCompilerPass(new RequestMethodPass());
     }
 
     public function getPath(): string

--- a/src/DependencyInjection/Compiler/RequestMethodPass.php
+++ b/src/DependencyInjection/Compiler/RequestMethodPass.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Beelab\Recaptcha2Bundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+final class RequestMethodPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container): void
+    {
+        $service = $container->getDefinition('beelab_recaptcha2.google_recaptcha');
+        $methodClass = $container->getParameter('beelab_recaptcha2.request_method');
+        $methodService = $container->getDefinition($methodClass);
+        $service->replaceArgument(1, $methodService);
+    }
+}


### PR DESCRIPTION
We need a compiler pass, otherwise the service injected as request method is not called properly (i.e. the setter is not called, resulting in an exception when used)